### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/web-nginx-php55/service/docker-entrypoint.sh
+++ b/web-nginx-php55/service/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 rm -f /docker-entrypoint.sh
 
 # Configure Nginx
-mkdir mkdir /run/nginx
+mkdir /run/nginx
 touch /run/nginx/nginx.pid
 
 # Get the user


### PR DESCRIPTION
在[web-nginx-php55/service/docker-entrypoint.she](https://github.com/CTF-Archives/ctf-docker-template/tree/main/web-nginx-php55/service/docker-entrypoint.sh)文件里，配置nginx时多出一个mkdir命令，被前面mkdir命令解释为文件夹名，在/var/www/html目录下创建了一个名为mkdir的目录

![mkdir](https://github.com/user-attachments/assets/ccc4a7ec-e16a-405d-aa02-6f48095c1d2d)

![mkdir1](https://github.com/user-attachments/assets/50d05b18-3d28-4677-97df-03db9574264d)
